### PR TITLE
Fix endpoint transfer collisions by utilizing usbd mutex

### DIFF
--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -1256,7 +1256,11 @@ bool usbd_edpt_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t * buffer, uint16_t 
   // could return and USBD task can preempt and clear the busy
   _usbd_dev.ep_status[epnum][dir].busy = 1;
 
-  if ( dcd_edpt_xfer(rhport, ep_addr, buffer, total_bytes) )
+  (void) osal_mutex_lock(_usbd_mutex, OSAL_TIMEOUT_WAIT_FOREVER);
+  bool xfer_result = dcd_edpt_xfer(rhport, ep_addr, buffer, total_bytes);
+  (void) osal_mutex_unlock(_usbd_mutex);
+
+  if (xfer_result)
   {
     return true;
   }else
@@ -1290,7 +1294,11 @@ bool usbd_edpt_xfer_fifo(uint8_t rhport, uint8_t ep_addr, tu_fifo_t * ff, uint16
   // and usbd task can preempt and clear the busy
   _usbd_dev.ep_status[epnum][dir].busy = 1;
 
-  if (dcd_edpt_xfer_fifo(rhport, ep_addr, ff, total_bytes))
+  (void) osal_mutex_lock(_usbd_mutex, OSAL_TIMEOUT_WAIT_FOREVER);
+  bool xfer_result = dcd_edpt_xfer_fifo(rhport, ep_addr, ff, total_bytes);
+  (void) osal_mutex_unlock(_usbd_mutex);
+
+  if (xfer_result)
   {
     TU_LOG_USBD("OK\r\n");
     return true;


### PR DESCRIPTION
This PR fixes an issue where endpoint transfers could collide if the timing was right. In particular, we noticed this when there was high frequency of HID input reports along side vendor bulk transfers (on different tasks). Apparently, the lower level code in portable/synopsys/dwc2/dcd_dwc2.c is vulnerable to register corruption with the right task preemption timing.

**Additional context**
Since the code in dcd_dwc2.c doesn't really interact at all with the RTOS, I ended up adding the synchronization in the USB device code, especially since there was already a priority inheriting mutex available at that level.

I believe the crux of the issue is in the function `edpt_schedule_packets`, which does a two stage read-then-write update to a common USB core register:
```
    if ( total_bytes != 0 )
    {
      dwc2->diepempmsk |= (1 << epnum);
    }
```
Presumably, when the timing is just right the existing value is stale due to a preemption between the read and write instructions required for `|=`