### PR TITLE
Add a callback for USB bus reset

### DIFF
--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -502,6 +502,7 @@ void tud_task_ext(uint32_t timeout_ms, bool in_isr)
     {
       case DCD_EVENT_BUS_RESET:
         TU_LOG_USBD(": %s Speed\r\n", tu_str_speed[event.bus_reset.speed]);
+        if (tud_reset_cb) tud_reset_cb();
         usbd_reset(event.rhport);
         _usbd_dev.speed = event.bus_reset.speed;
       break;

--- a/src/device/usbd.h
+++ b/src/device/usbd.h
@@ -148,6 +148,9 @@ TU_ATTR_WEAK void tud_suspend_cb(bool remote_wakeup_en);
 // Invoked when usb bus is resumed
 TU_ATTR_WEAK void tud_resume_cb(void);
 
+// Invoked when a bus reset occurs
+TU_ATTR_WEAK void tud_reset_cb(void);
+
 // Invoked when received control request with VENDOR TYPE
 TU_ATTR_WEAK bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_request_t const * request);
 


### PR DESCRIPTION
**Describe the PR**
This PR adds a bus reset callback that the app layer can observe, which can be useful to resetting USB variables.

**Additional context**
Although each class driver does have its own reset callback, these are internally consumed for reseting the driver state and there wasn't a general reset callback exposed.
