### PR TITLE
fix: update component yaml to change `targets` to `matches` since oth…

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -4,7 +4,5 @@ documentation: "https://docs.tinyusb.org/en/latest/"
 repository: "https://github.com/espressif/tinyusb.git"
 dependencies:
   idf: '>=5.0' # IDF 4.x contains TinyUSB as submodule
-targets:
-  - esp32s2
-  - esp32s3
-  - esp32p4
+matches:
+  - if: "target in [esp32s2, esp32s3, esp32p4]"


### PR DESCRIPTION
**Describe the PR**
A clear and concise description of what this PR solve.

Local and cloud builds of `esp32` projects which happen to point to a `components` directory containing `tinyusb` fail because tinyusb is improperly registered, even though those projects do not actually `REQUIRE` `tinyusb`.

By changing `targets` to a `matches` set of rules, then the builds succeed. This is likely a bug in the esp-idf component yaml processing.
