### PR TITLE
FIR-337 usb has a tendency to crash on configuration changes

### DIFF
--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -1272,7 +1272,6 @@ bool usbd_edpt_release(uint8_t rhport, uint8_t ep_addr)
 
 bool usbd_edpt_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t * buffer, uint16_t total_bytes)
 {
-  bool xfer_result = true;
   rhport = _usbd_rhport;
 
   uint8_t const epnum = tu_edpt_number(ep_addr);
@@ -1291,7 +1290,7 @@ bool usbd_edpt_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t * buffer, uint16_t 
   _usbd_dev.ep_status[epnum][dir].busy = 1;
 
   (void) osal_mutex_lock(_usbd_mutex, OSAL_TIMEOUT_WAIT_FOREVER);
-  xfer_result = dcd_edpt_xfer(rhport, ep_addr, buffer, total_bytes);
+  bool xfer_result = dcd_edpt_xfer(rhport, ep_addr, buffer, total_bytes);
   (void) osal_mutex_unlock(_usbd_mutex);
 
   if (xfer_result)

--- a/src/device/usbd.h
+++ b/src/device/usbd.h
@@ -96,6 +96,9 @@ bool tud_disconnect(void);
 // Return false on unsupported MCUs
 bool tud_connect(void);
 
+// Unmount device clearing configurations
+void tud_unmount(void);
+
 // Carry out Data and Status stage of control transfer
 // - If len = 0, it is equivalent to sending status only
 // - If len > wLength : it will be truncated

--- a/src/osal/osal_freertos.h
+++ b/src/osal/osal_freertos.h
@@ -208,6 +208,11 @@ TU_ATTR_ALWAYS_INLINE static inline bool osal_queue_empty(osal_queue_t qhdl)
   return uxQueueMessagesWaiting(qhdl) == 0;
 }
 
+TU_ATTR_ALWAYS_INLINE static inline void osal_queue_reset(osal_queue_t qhdl)
+{
+  xQueueReset(qhdl);
+}
+
 #ifdef __cplusplus
  }
 #endif


### PR DESCRIPTION
Fix Linear issue [FIR-337 USB has a tendency to crash on configuration changes](https://linear.app/backbonelabs/issue/FIR-337/usb-has-a-tendency-to-crash-on-configuration-changes)

I added a tud_unmount() function in the tinyusb.
This function performs the following post-processing after deleting the tud_task_ext() task:

- Clear endpoint information
- Clear USB device information
- Clear configuration information
- Reset Class drivers
- Clear event queue
- Reset DCD (PHY)
These data are not cleared by the bb::usb::stop() process, so endpoint communication continues to operate.
This fix requires changes ([PR-340](https://github.com/Backbone-Labs/niji/pull/340)) in the Niji.
