### PR TITLE
FIR-572 update bb usb implementation to utilize tinyusb uninstall

### DIFF
--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -574,7 +574,6 @@ bool tud_deinit(uint8_t rhport) {
   _usbd_q = NULL;
 
 #if OSAL_MUTEX_REQUIRED
-  // TODO make sure there is no task waiting on this mutex
   // make sure there is no task waiting on this mutex
   (void) osal_mutex_lock(_usbd_mutex, OSAL_TIMEOUT_WAIT_FOREVER);
   osal_mutex_delete(_usbd_mutex);

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -575,6 +575,8 @@ bool tud_deinit(uint8_t rhport) {
 
 #if OSAL_MUTEX_REQUIRED
   // TODO make sure there is no task waiting on this mutex
+  // make sure there is no task waiting on this mutex
+  (void) osal_mutex_lock(_usbd_mutex, OSAL_TIMEOUT_WAIT_FOREVER);
   osal_mutex_delete(_usbd_mutex);
   _usbd_mutex = NULL;
 #endif
@@ -1377,6 +1379,8 @@ bool usbd_edpt_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t* buffer, uint16_t t
 
   // Attempt to transfer on a busy endpoint, sound like an race condition !
   TU_ASSERT(_usbd_dev.ep_status[epnum][dir].busy == 0);
+  // If mutex has already been deleted, return
+  TU_VERIFY(_usbd_mutex);
 
   // Set busy first since the actual transfer can be complete before dcd_edpt_xfer()
   // could return and USBD task can preempt and clear the busy

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -553,6 +553,7 @@ bool tud_deinit(uint8_t rhport) {
   // Deinit device controller driver
   dcd_int_disable(rhport);
   dcd_disconnect(rhport);
+  dcd_edpt_close_all(rhport);
   dcd_deinit(rhport);
 
   // Deinit class drivers
@@ -563,6 +564,10 @@ bool tud_deinit(uint8_t rhport) {
       driver->deinit();
     }
   }
+
+  tu_varclr(&_usbd_dev);
+  memset(_usbd_dev.itf2drv, DRVID_INVALID, sizeof(_usbd_dev.itf2drv)); // invalid mapping
+  memset(_usbd_dev.ep2drv, DRVID_INVALID, sizeof(_usbd_dev.ep2drv)); // invalid mapping
 
   // Deinit device queue & task
   osal_queue_delete(_usbd_q);

--- a/src/tusb.c
+++ b/src/tusb.c
@@ -383,7 +383,7 @@ uint32_t tu_edpt_stream_write_xfer(uint8_t hwid, tu_edpt_stream_t* s) {
   uint16_t const count = tu_fifo_read_n(&s->ff, s->ep_buf, s->ep_bufsize);
 
   if (count) {
-    TU_ASSERT(stream_xfer(hwid, s, count), 0);
+    TU_VERIFY(stream_xfer(hwid, s, count), 0);
     return count;
   } else {
     // Release endpoint since we don't make any transfer
@@ -401,7 +401,7 @@ uint32_t tu_edpt_stream_write(uint8_t hwid, tu_edpt_stream_t* s, void const* buf
     TU_VERIFY(stream_claim(hwid, s), 0);
     const uint32_t xact_len = tu_min32(bufsize, s->ep_bufsize);
     memcpy(s->ep_buf, buffer, xact_len);
-    TU_ASSERT(stream_xfer(hwid, s, (uint16_t) xact_len), 0);
+    if (!stream_xfer(hwid, s, (uint16_t) xact_len)) return 0;
     return xact_len;
   } else {
     const uint16_t ret = tu_fifo_write_n(&s->ff, buffer, (uint16_t) bufsize);

--- a/src/tusb.c
+++ b/src/tusb.c
@@ -119,6 +119,20 @@ bool tusb_inited(void) {
   return ret;
 }
 
+bool tusb_deinit(void) {
+  bool ret = false;
+
+  #if CFG_TUD_ENABLED
+  ret = ret || tud_deinit(0);
+  #endif
+
+  #if CFG_TUH_ENABLED
+  ret = ret || tuh_deinit(1);
+  #endif
+
+  return ret;
+}
+
 void tusb_int_handler(uint8_t rhport, bool in_isr) {
   TU_VERIFY(rhport < TUP_USBIP_CONTROLLER_NUM,);
 

--- a/src/tusb.h
+++ b/src/tusb.h
@@ -151,6 +151,9 @@ bool tusb_rhport_init(uint8_t rhport, const tusb_rhport_init_t* rh_init);
 // Check if stack is initialized
 bool tusb_inited(void);
 
+// Release the stack
+bool tusb_deinit(void);
+
 // Called to handle usb interrupt/event. tusb_init(rhport, role) must be called before
 void tusb_int_handler(uint8_t rhport, bool in_isr);
 


### PR DESCRIPTION
This PR is for preliminary code review.

This PR solves the following issue:
https://linear.app/backbonelabs/issue/FIR-572/update-bb-usb-implementation-to-utilize-tinyusb-uninstall

At this time, operation has only been confirmed on Android Pixel5 phone.
The Apple Auth IC in my preEVT sample is broken (This is the only Auth IC on the I2C_400K bus that does not return an ACK.), so I will have Minagawa-san repair it on next Monday.
Therefore, operation has not yet been confirmed on iPhone.

This change will completely disable DCD on tinyusb driver uninstall.
This change will be combined with the changes in the niji repository.