### PR TITLE
FIR-799/1238 Suppress assertion after USB PHY is stopped

### DIFF
--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -747,7 +747,7 @@ void tud_task_ext(uint32_t timeout_ms, bool in_isr) {
 
 #if CFG_TUSB_OS != OPT_OS_NONE && CFG_TUSB_OS != OPT_OS_PICO
     // return if there is no more events, for application to run other background
-    if (osal_queue_empty(_usbd_q)) return;
+    if (!_usbd_q || osal_queue_empty(_usbd_q)) return;
 #endif
   }
 }


### PR DESCRIPTION
This PR solves the following problems in the FIR-799 / 1238 tasks:
If osal_queue_empty() is executed immediately after the USB PHY is stopped, it will enter the assert state in the osal_queue_empty() function (Then the Niji reboots), so this modification suppresses this.

![image](https://github.com/user-attachments/assets/843937c7-5828-413f-8792-54ffc8b28d3d)

https://linear.app/backbonelabs/issue/FIR-799/investigate-whether-sleep-or-apb-locks-can-be-released-for-usb-suspend
https://linear.app/backbonelabs/issue/FIR-1238/update-bsp-to-support-new-d-external-pull-up-iox-pin

